### PR TITLE
ViewHelperProviderInterface

### DIFF
--- a/src/LaminasModuleProvider.php
+++ b/src/LaminasModuleProvider.php
@@ -21,6 +21,7 @@ use Laminas\ModuleManager\Feature\RouteProviderInterface;
 use Laminas\ModuleManager\Feature\SerializerProviderInterface;
 use Laminas\ModuleManager\Feature\ServiceProviderInterface;
 use Laminas\ModuleManager\Feature\ValidatorProviderInterface;
+use Laminas\ModuleManager\Feature\ViewHelperProviderInterface;
 use Traversable;
 
 /**
@@ -62,6 +63,7 @@ class LaminasModuleProvider
             'hydrators' => $this->getHydratorConfig(),
             'input_filters' => $this->getInputFilterConfig(),
             'serializers' => $this->getSerializerConfig(),
+            'view_helpers' => $this->getViewHelperConfig(),
         ]));
     }
 
@@ -177,7 +179,7 @@ class LaminasModuleProvider
         return $this->convert($this->module->getHydratorConfig());
     }
 
-    public function getInputFilterConfig()
+    public function getInputFilterConfig() /* : array */
     {
         if (! $this->module instanceof InputFilterProviderInterface) {
             return [];
@@ -193,5 +195,14 @@ class LaminasModuleProvider
         }
 
         return $this->convert($this->module->getSerializerConfig());
+    }
+
+    public function getViewHelperConfig() : array
+    {
+        if (! $this->module instanceof ViewHelperProviderInterface) {
+            return [];
+        }
+
+        return $this->convert($this->module->getViewHelperConfig());
     }
 }

--- a/test/LaminasModuleProviderTest.php
+++ b/test/LaminasModuleProviderTest.php
@@ -19,6 +19,7 @@ use Laminas\ModuleManager\Feature\InputFilterProviderInterface;
 use Laminas\ModuleManager\Feature\RouteProviderInterface;
 use Laminas\ModuleManager\Feature\SerializerProviderInterface;
 use Laminas\ModuleManager\Feature\ValidatorProviderInterface;
+use Laminas\ModuleManager\Feature\ViewHelperProviderInterface;
 use LaminasTest\ConfigAggregatorModuleManager\Resources\LaminasModule;
 use LaminasTest\ConfigAggregatorModuleManager\Resources\LaminasModuleWithInvalidConfiguration;
 use LaminasTest\ConfigAggregatorModuleManager\Resources\LaminasModuleWithLaminasConfig;
@@ -148,6 +149,21 @@ class LaminasModuleProviderTest extends TestCase
         $this->assertSame($this->createServiceManagerConfiguration(), $config['serializers']);
     }
 
+    public function testCanProviderViewHelpersFromViewHelperProviderInterface()
+    {
+        $module = $this->createMock(ViewHelperProviderInterface::class);
+        $module
+            ->expects($this->once())
+            ->method('getViewHelperConfig')
+            ->willReturn($this->createServiceManagerConfiguration());
+
+        $provider = new LaminasModuleProvider($module);
+
+        $config = $provider();
+        $this->assertArrayHasKey('view_helpers', $config);
+        $this->assertSame($this->createServiceManagerConfiguration(), $config['view_helpers']);
+    }
+
     public function testCanProvideAnyConfigValue()
     {
         $module = new LaminasModule();
@@ -191,7 +207,7 @@ class LaminasModuleProviderTest extends TestCase
         $this->assertSame($this->createServiceManagerConfiguration(), $config['dependencies']);
     }
 
-    public function testCanHandleModuelsWithLaminasConfigConfiguration()
+    public function testCanHandleModulesWithLaminasConfigConfiguration()
     {
         $module = new LaminasModuleWithTraversableConfig();
         $provider = new LaminasModuleProvider($module);


### PR DESCRIPTION
This re-opens zendframework/zend-config-aggregator-modulemanager#3 and handles #1 

#### Summary

I forgot to implement the `ViewHelperProviderInterface` in the initial release.

