### PR TITLE
PHP 8.0 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /laminas-mkdoc-theme/
 /phpunit.xml
 /vendor/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,32 +12,34 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=lowest
-    - php: 7.2
+    - php: 7.4
       env:
         - DEPS=latest
-    - php: 7.3
+    - php: 8.0
       env:
         - DEPS=lowest
-    - php: 7.3
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - php: 8.0
       env:
         - DEPS=latest
+        - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
 
 before_install:
   - if [[ $TEST_COVERAGE != 'true' ]]; then phpenv config-rm xdebug.ini || return 0 ; fi
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
+  - travis_retry composer install $COMPOSER_ARGS
   - if [[ $LEGACY_DEPS != '' ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#7](https://github.com/laminas/laminas-config-aggregator-modulemanager/pull/7) Adds PHP 8.0 support
 
 ### Changed
 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "extra": {
     },
     "require": {
-        "php": "^7.1",
+        "php": "^7.3 || ~8.0.0",
         "laminas/laminas-config-aggregator": "^1.1",
         "laminas/laminas-modulemanager": "^2.8",
         "laminas/laminas-zendframework-bridge": "^1.0"
@@ -26,7 +26,7 @@
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-config": "^3.1",
         "laminas/laminas-servicemanager": "^3.3",
-        "phpunit/phpunit": "^7.0.3"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
-<phpunit bootstrap="./vendor/autoload.php" colors="true">
-    <testsuites>
-        <testsuite name="laminas-config-aggregator-modulemanager">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./vendor/autoload.php" colors="true" xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="laminas-config-aggregator-modulemanager">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/test/LaminasModuleProviderTest.php
+++ b/test/LaminasModuleProviderTest.php
@@ -218,11 +218,9 @@ class LaminasModuleProviderTest extends TestCase
         $this->assertSame($this->createServiceManagerConfiguration(), $config['dependencies']);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testThrowsInvalidArgumentExceptionOnInvalidConfiguration()
     {
+        $this->expectException(InvalidArgumentException::class);
         $module = new LaminasModuleWithInvalidConfiguration();
         $provider = new LaminasModuleProvider($module);
 


### PR DESCRIPTION

Q | A
-- | --
New Feature | yes

Summary
To be prepared for the December release of PHP 8.0, this repository has some additional TODOs to be tested against the new major version.

In order to make this repository compatible, one has to follow these steps:

- [x] Modify composer.json to provide support for PHP 8.0 by adding the constraint ~8.0.0
- [x] Modify composer.json to drop support for PHP less than 7.3
- [x] Modify composer.json to implement PHPUnit 9.3 which supports PHP 7.3+
- [x] Modify .travis.yml to ignore platform requirements when installing composer dependencies (simply add --ignore-platform-reqs to COMPOSER_ARGS env variable)
- [x] Modify .travis.yml to add PHP 8.0 to the matrix (NOTE: Do not allow failures as PHP 8.0 has a feature freeze since 2020-08-04!)
- [x] Modify source code in case there are incompatibilities with PHP 8.0

closes #6 