### PR TITLE
Drop `laminas/laminas-zendframework-bridge` and `zendframework/*` compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
     "require": {
         "php": "^7.3 || ~8.0.0",
         "laminas/laminas-config-aggregator": "^1.1",
-        "laminas/laminas-modulemanager": "^2.8",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-modulemanager": "^2.8"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
@@ -48,7 +47,7 @@
         "test": "phpunit --colors=always",
         "test-coverage": "phpunit --colors=always --coverage-clover clover.xml"
     },
-    "replace": {
-        "zendframework/zend-config-aggregator-modulemanager": "^1.0.1"
+    "conflict": {
+        "zendframework/zend-config-aggregator-modulemanager": "*"
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description


Increase performance by removing a compatibility layer while **not** introducing breaking changes.

This follow the process described in details in:

https://github.com/laminas/technical-steering-committee/blob/main/meetings/minutes/2021-08-02-TSC-Minutes.md#remove-laminaslaminas-zendframework-bridge-dependency-from-our-packages
